### PR TITLE
Deploy documentation to GitHub Pages

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+Changelog
+---------
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+Checklist
+---------
+
+- [ ] Test
+- [ ] Self-review
+- [ ] Documentation

--- a/.github/workflows/documentation-ci-cd.yml
+++ b/.github/workflows/documentation-ci-cd.yml
@@ -49,6 +49,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: doc/build/html
-          enable_jekyll: true
           user_name: ${{ env.USER }}
           user_email: ${{ env.EMAIL }}

--- a/.github/workflows/documentation-ci-cd.yml
+++ b/.github/workflows/documentation-ci-cd.yml
@@ -1,0 +1,62 @@
+# Copyright Jiaqi Liu
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+name: Documentation CI/CD
+
+"on":
+  pull_request:
+  push:
+    branches:
+      - master
+
+env:
+  USER: QubitPi
+  EMAIL: jack20220723@gmail.com
+
+jobs:
+  release:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.7"
+      - name: Install dependencies
+        run: |
+          sudo apt-get install liberasurecode-dev
+          git clone https://github.com/openstack/liberasurecode.git
+          cd liberasurecode
+          ./autogen.sh
+          ./configure
+          make
+          make test
+          sudo make install
+          cd ../
+          pip install swift
+          pip install -r requirements.txt -r doc/requirements.txt
+      - name: Build doc
+        run: sphinx-build -b html doc/source doc/build/html
+      - name: Deploy documentation to GitHub Pages
+        #if: github.ref == 'refs/heads/master'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: doc/build/html
+          enable_jekyll: true
+          user_name: ${{ env.USER }}
+          user_email: ${{ env.EMAIL }}

--- a/.github/workflows/documentation-ci-cd.yml
+++ b/.github/workflows/documentation-ci-cd.yml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   release:
-    name: Deploy to GitHub Pages
+    name: Test & Release Documentation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -39,20 +39,12 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get install liberasurecode-dev
-          git clone https://github.com/openstack/liberasurecode.git
-          cd liberasurecode
-          ./autogen.sh
-          ./configure
-          make
-          make test
-          sudo make install
-          cd ../
           pip install swift
           pip install -r requirements.txt -r doc/requirements.txt
-      - name: Build doc
+      - name: Build documentation
         run: sphinx-build -b html doc/source doc/build/html
       - name: Deploy documentation to GitHub Pages
-        #if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -48,6 +48,8 @@ sys.path.extend([os.path.abspath('../swift'), os.path.abspath('..'),
 
 # -- General configuration ----------------------------------------------------
 
+html_baseurl = '/openstack-swift/'
+
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc',


### PR DESCRIPTION
Changelog
---------

### Added

- Added documentation CI/CD

  - Every pull request triggers documentation build test
  - Each `master` branch commit triggers the same build test above and, if successful, automatically deploys documentation to GitHub Pages

### Changed

- Added base path to sphinx config so that the doc resources loads properly on GitHub Pages

### Deprecated

### Removed

### Fixed

### Security

Checklist
---------

- [x] Test
- [x] Self-review
- [x] Documentation
